### PR TITLE
Fix bug

### DIFF
--- a/mass_api_client/connection_manager.py
+++ b/mass_api_client/connection_manager.py
@@ -56,7 +56,7 @@ class Connection:
         json_files['metadata'] = ('metadata', metadata)
 
         for key, value in json_files.items():
-            files[key] = (value[0], json.dumps(value[1]), 'application/json')
+            files[key] = (None, json.dumps(value[1]), 'application/json')
 
         for key, value in binary_files.items():
             files[key] = (value[0], value[1], 'binary/octet-stream')

--- a/mass_api_client/connection_manager.py
+++ b/mass_api_client/connection_manager.py
@@ -53,10 +53,10 @@ class Connection:
 
         headers = self._default_headers.copy()
         headers.pop('content-type')
-        json_files['metadata'] = ('metadata', metadata)
+        json_files['metadata'] = (None, metadata)
 
         for key, value in json_files.items():
-            files[key] = (None, json.dumps(value[1]), 'application/json')
+            files[key] = (value[0], json.dumps(value[1]), 'application/json')
 
         for key, value in binary_files.items():
             files[key] = (value[0], value[1], 'binary/octet-stream')

--- a/tests/httmock_test_case.py
+++ b/tests/httmock_test_case.py
@@ -14,6 +14,14 @@ class HTTMockTestCase(unittest.TestCase):
     def assertAuthorized(self, request):
         self.assertEqual(request.headers['Authorization'], 'APIKEY {}'.format(self.api_key))
 
+    def assertHasForm(self, request, form_index, file, content_type=None):
+        request_form = request.original.files[form_index]
+        self.assertEqual(request_form[0], None)
+        self.assertEqual(request_form[1], file)
+
+        if content_type:
+            self.assertEqual(request_form[2], content_type)
+
     def assertHasFile(self, request, file_index, file_name, file, content_type=None):
         request_file = request.original.files[file_index]
         self.assertEqual(request_file[0], file_name)

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -37,7 +37,7 @@ class MASSApiTestCase(HTTMockTestCase):
             def mass_mock_post_file(url, request):
                 self.assertAuthorized(request)
                 self.assertHasFile(request, 'file', 'test_data', data_file)
-                self.assertHasFile(request, 'metadata', 'metadata', json.dumps(self.example_data), 'application/json')
+                self.assertHasForm(request, 'metadata', json.dumps(self.example_data), 'application/json')
                 return json.dumps(self.example_data)
 
             with HTTMock(mass_mock_post_file):

--- a/tests/test_object_creation.py
+++ b/tests/test_object_creation.py
@@ -37,7 +37,7 @@ class ObjectCreationTestCase(HTTMockTestCase):
         def mass_mock_creation(url, request):
             self.assertAuthorized(request)
             self.assertHasFile(request, 'file', filename, file)
-            self.assertHasFile(request, 'metadata', 'metadata', json.dumps(metadata), content_type='application/json')
+            self.assertHasForm(request, 'metadata', json.dumps(metadata), content_type='application/json')
             return json.dumps(response_data)
 
         with HTTMock(mass_mock_creation):


### PR DESCRIPTION
Use filename=None to ensure that metadata ends up in request.form in MASS
submit_file